### PR TITLE
Partial fix for #391 - Charge movement improvement (#433)

### DIFF
--- a/src/game/Movement/PointMovementGenerator.cpp
+++ b/src/game/Movement/PointMovementGenerator.cpp
@@ -270,6 +270,7 @@ void ChargeMovementGenerator<T>::ComputePath(T& attacker, Unit& victim)
                 {
                     victim.UpdateAllowedPositionZ(victimPos.x, victimPos.y, victimPos.z);
                     path.calculate(victimPos.x, victimPos.y, victimPos.z, false);
+                    path.UpdateForMelee(&victim, attacker.GetMeleeReach());
                 }
             }
             else


### PR DESCRIPTION
After computing the victim's future estimated position, we update the path so that the target is within melee reach.
After some tests, this allows the player to not face a wrong direction after charge except when the player is moving towards the caster.
This is not a perfect solution yet and I'm working on a rework.