### PR TITLE
Uses a proper ACE_HANDLE type for logging

### DIFF
--- a/src/game/Protocol/WorldSocket.cpp
+++ b/src/game/Protocol/WorldSocket.cpp
@@ -56,7 +56,9 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
     new_pct->FillPacketTime(WorldTimer::getMSTime());
 
     // Dump received packet.
-    sLog.outWorldPacketDump(uint64(get_handle()), new_pct->GetOpcode(), LookupOpcodeName(new_pct->GetOpcode()), new_pct, true);
+    sLog.outWorldPacketDump(get_handle(), new_pct->GetOpcode(),
+                            LookupOpcodeName(new_pct->GetOpcode()), new_pct,
+                            true);
 
     try
     {
@@ -160,7 +162,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     std::string safe_account = account; // Duplicate, else will screw the SHA hash verification below
     LoginDatabase.escape_string(safe_account);
     // No SQL injection, username escaped.
-                             
+
     QueryResult *result = LoginDatabase.PQuery("SELECT a.id, aa.gmLevel, a.sessionkey, a.last_ip, a.locked, a.v, a.s, a.mutetime, a.locale, a.os, a.flags, "
         "ab.unbandate > UNIX_TIMESTAMP() OR ab.unbandate = ab.bandate FROM account a LEFT JOIN account_access aa ON a.id = aa.id AND aa.RealmID IN (-1, %u) "
         "LEFT JOIN account_banned ab ON a.id = ab.id AND ab.active = 1 WHERE a.username = '%s' ORDER BY aa.RealmID DESC LIMIT 1", realmID, safe_account.c_str());

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -109,7 +109,7 @@ void Log::InitSmartlogEntries(const std::string& str)
     while (ss)
     {
         ss >> entry;
-        m_smartlogExtraEntries.push_back(entry);        
+        m_smartlogExtraEntries.push_back(entry);
     }
 }
 
@@ -876,16 +876,19 @@ void Log::outCommand( uint32 account, const char * str, ... )
     fflush(stdout);
 }
 
-void Log::outWorldPacketDump( uint64 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming )
+void Log::outWorldPacketDump(ACE_HANDLE socketHandle, uint32 opcode,
+                             char const* opcodeName, ByteBuffer const* packet,
+                             bool incoming)
 {
     if (!worldLogfile)
         return;
 
     outTimestamp(worldLogfile);
 
-    fprintf(worldLogfile,"\n%s:\nSOCKET: %llu\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
-        incoming ? "CLIENT" : "SERVER",
-        socket, packet->size(), opcodeName, opcode);
+    fprintf(worldLogfile,
+            "\n%s:\nSOCKET: %llu\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
+            incoming ? "CLIENT" : "SERVER", socketHandle, packet->size(),
+            opcodeName, opcode);
 
     size_t p = 0;
     while (p < packet->size())

--- a/src/shared/Log.h
+++ b/src/shared/Log.h
@@ -184,7 +184,9 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, ACE_Th
                                                             // any log level
         void outErrorDb( const char * str, ... )     ATTR_PRINTF(2,3);
                                                             // any log level
-        void outWorldPacketDump( uint64 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming );
+        void outWorldPacketDump(ACE_HANDLE socketHandle, uint32 opcode,
+                                char const* opcodeName,
+                                ByteBuffer const* packet, bool incoming);
         // any log level
         uint32 GetLogLevel() const { return m_logLevel; }
         void SetLogLevel(char * Level);


### PR DESCRIPTION
Changes socket handle type to platform specific ACE_HANDLE instead of
explicitly casting the pointer to uint64.